### PR TITLE
Add command for looking through PRs in diff mode

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -164,6 +164,10 @@ let g:user_emmet_expandabbr_key = '<c-e>'
 " Easymotion config
 map , <Plug>(easymotion-prefix)
 
+" Move back and forth in the args file list with Gdiff to origin/master
+map [g :wincmd l<CR>:only<CR>:prev<CR>:Gdiff origin/master<CR>
+map ]g :wincmd l<CR>:only<CR>:next<CR>:Gdiff origin/master<CR>
+
 " Local config
 if filereadable($HOME . "/.vimrc.local")
   source ~/.vimrc.local


### PR DESCRIPTION
This command is made for looking through pull requests. What it does:
it closes the last Gdiff origin/master pane by moving to the right pane
(fugitive opens diffs to the left) and closes all other panes/windows
then it moves to the next file in the args list and opens a new `Gdiff
origin/master` diff

To use this mapping you have to make sure you set vim's file args list to
the files you want to compare to origin/master,
e.g. `vim \`git diff --name-only origin/master..HEAD``
